### PR TITLE
Invert taste slider: sweeter increases second pour

### DIFF
--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -158,7 +158,7 @@ export default {
 
     // 4:6 method: first 40% of water is for first two pours:
     step1() {
-      return Math.round(this.firstPartWater * this.taste);
+      return Math.round(this.firstPartWater * (1 - this.taste));
     },
     step2() {
       return this.firstPartWater - this.step1;


### PR DESCRIPTION
## What
Invert the taste slider direction so sliding toward "Sweeter" increases the second pour and decreases the first; toward "Brighter" increases the first pour.

## Why
This aligns with the 4:6 method expectations: sweeter profile => smaller first pour, larger second pour.

## Behavior
- Before: Moving toward “Sweeter” increased the first pour.
- After: Moving toward “Sweeter” decreases the first pour and increases the second.

## Scope
- Only updates `src/components/Calculator.vue` `step1` calculation; no other changes.

## How I tested
1. `npm install`
2. Run with Node 16 (or `NODE_OPTIONS=--openssl-legacy-provider npm run serve`)
3. Move the “Brighter ⇄ Sweeter” slider and verify:
   - Sweeter → `step1` decreases, `step2` increases
   - Brighter → `step1` increases, `step2` decreases

<img width="565" height="570" alt="image" src="https://github.com/user-attachments/assets/e4febf78-e63b-4442-b6f9-8eb62f80d460" />

## Notes
Appreciate the project! This is a small, focused change to make the slider behavior match expectations.

## Checklist
- [x] Builds locally
- [x] Lint passes
- [x] No unrelated changes